### PR TITLE
Fix segfault when detecting the kernel on NixOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ clean:
 	rm -rf $(OBJDIR) $(BINDIR)
 
 install: $(TARGET)
-	mkdir -pv $(INSTALLDIR)
 	install -Dm755 $< $(INSTALLDIR)/$(APPNAME)
 
 uninstall:

--- a/patches/001_kernel.patch
+++ b/patches/001_kernel.patch
@@ -1,0 +1,13 @@
+diff --git a/src/kernel.c b/src/kernel.c
+index c3d7ee0..0d3bd7e 100644
+--- a/src/kernel.c
++++ b/src/kernel.c
+@@ -16,7 +16,7 @@ char *catch_kerver(void) {
+         exit(EXIT_FAILURE);
+     }
+ 
+-    char *release = malloc(sizeof(char) * strlen(buffer.release));
++    char *release = malloc(sizeof(char) * (strlen(buffer.release) + 1));
+     sprintf(release, "%s", buffer.release);
+ 
+     return release;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -16,7 +16,7 @@ char *catch_kerver(void) {
         exit(EXIT_FAILURE);
     }
 
-    char *release = malloc(sizeof(char) * strlen(buffer.release));
+    char *release = malloc(sizeof(char) * (strlen(buffer.release) + 1));
     sprintf(release, "%s", buffer.release);
 
     return release;


### PR DESCRIPTION
# Before Patch
![image](https://github.com/AlphaTechnolog/cutefetch/assets/92590433/f29c2cd2-3dac-41b3-a9b1-3537cf4f30b9)

# After Patch
![image](https://github.com/AlphaTechnolog/cutefetch/assets/92590433/59c4a4f3-8c52-4af5-af19-02b5492e0ceb)
